### PR TITLE
Add ability to make an alpine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2.1
 
 jobs:
   build:
+    docker:
+      - image: docker:stable-git
     steps:
       - checkout
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,9 @@ version: 2.1
 
 jobs:
   build:
-    docker:
-      - image: docker:stable-git
+    machine: true
     steps:
       - checkout
-      - run: apk add --no-cache make
       - run: make image
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+---
+version: 2.1
+orbs:
+  docker: circleci/docker@0.5.1
+  clair-scanner: ovotech/clair-scanner@1.4.33
+
+jobs:
+  build:
+    executor: docker/machine
+    steps:
+      - checkout
+      - docker/check
+      - run: |
+          make image
+          echo $(docker image inspect --format="{{index .RepoDigests 0}}" minimsecure/ruby-docker-image) > /tmp/image.txt
+      - store_artifacts:
+          path: /tmp/image.txt
+          destination: image
+
+  scan:
+    executor: clair-scanner/default
+    steps:
+      - checkout
+      - clair/scan:
+          image_file:
+            /tmp/image.txt
+
+workflows:
+  build_test_deploy:
+    jobs:
+      - build
+      - scan:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,10 @@
 ---
 version: 2.1
-orbs:
-  docker: circleci/docker@0.5.1
 
 jobs:
   build:
-    executor: docker/machine
     steps:
       - checkout
-      - docker/check
       - run: |
           make image
           echo $(docker image inspect --format="{{index .RepoDigests 0}}" minimsecure/ruby-docker-image) > /tmp/image.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@
 version: 2.1
 orbs:
   docker: circleci/docker@0.5.1
-  clair-scanner: ovotech/clair-scanner@1.4.33
 
 jobs:
   build:
@@ -17,18 +16,7 @@ jobs:
           path: /tmp/image.txt
           destination: image
 
-  scan:
-    executor: clair-scanner/default
-    steps:
-      - checkout
-      - clair/scan:
-          image_file:
-            /tmp/image.txt
-
 workflows:
   build_test_deploy:
     jobs:
       - build
-      - scan:
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - checkout
       - run: make image
+      - run: make image/alpine
 
 workflows:
   build_test_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,7 @@ jobs:
       - image: docker:stable-git
     steps:
       - checkout
-      - run: |
-          make image
-          echo $(docker image inspect --format="{{index .RepoDigests 0}}" minimsecure/ruby-docker-image) > /tmp/image.txt
-      - store_artifacts:
-          path: /tmp/image.txt
-          destination: image
+      - run: make image
 
 workflows:
   build_test_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - image: docker:stable-git
     steps:
       - checkout
+      - run: apk add --no-cache make
       - run: make image
 
 workflows:

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,7 @@
 FROM ruby:2.6.3-alpine3.9
 
-RUN apk --no-cache upgrade && apk --no-cache add curl nodejs nodejs-npm postgresql-client postgresql-dev fftw fftw-dev
+RUN apk --no-cache upgrade && \
+    apk --no-cache add curl nodejs nodejs-npm postgresql-client postgresql-dev fftw fftw-dev
 
 RUN npm install elasticdump -g
 RUN ACCEPT_HIGHCHARTS_LICENSE=YES npm install highcharts-export-server -g --unsafe-perm

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,19 @@
+FROM ruby:2.6.3-alpine3.9
+
+RUN apk --no-cache add curl nodejs nodejs-npm postgresql-client postgresql-dev fftw fftw-dev
+
+RUN npm install elasticdump -g
+RUN ACCEPT_HIGHCHARTS_LICENSE=YES npm install highcharts-export-server -g --unsafe-perm
+
+RUN apk --no-cache add ca-certificates wget && \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-bin-2.25-r0.apk && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-i18n-2.25-r0.apk && \
+    apk add glibc-bin-2.25-r0.apk glibc-i18n-2.25-r0.apk glibc-2.25-r0.apk
+
+RUN /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3-alpine3.9
 
-RUN apk --no-cache add curl nodejs nodejs-npm postgresql-client postgresql-dev fftw fftw-dev
+RUN apk --no-cache upgrade && apk --no-cache add curl nodejs nodejs-npm postgresql-client postgresql-dev fftw fftw-dev
 
 RUN npm install elasticdump -g
 RUN ACCEPT_HIGHCHARTS_LICENSE=YES npm install highcharts-export-server -g --unsafe-perm

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ image:
 .PHONY: image/alpine
 image/alpine:
 	docker build \
-		-t $(DOCKER_IMAGE)-alpine:$(VERSION) \
-		-t $(DOCKER_IMAGE)-alpine:latest \
+		-t $(DOCKER_IMAGE):$(VERSION)-alpine \
 		-f Dockerfile.alpine \
 		.
 
@@ -22,8 +21,7 @@ images: image image/alpine
 
 .PHONY: docker/push/alpine
 docker/push/alpine:
-	@docker push $(DOCKER_IMAGE)-alpine:$(VERSION)
-	@docker push $(DOCKER_IMAGE)-alpine:latest
+	@docker push $(DOCKER_IMAGE):$(VERSION)-alpine
 
 .PHONY: docker/push/image
 docker/push/image:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+VERSION?=$(shell git describe --tags 2> /dev/null || echo '0.0.0')
+DOCKER_IMAGE=minimsecure/ruby-docker-image
+
+.PHONY: image
+image:
+	docker build \
+		-t minimsecure/ruby-docker-image:$(VERSION) \
+		-t $(DOCKER_IMAGE):latest \
+		-f Dockerfile \
+		.
+
+.PHONY: image/alpine
+image/alpine:
+	docker build \
+		-t $(DOCKER_IMAGE)-alpine:$(VERSION) \
+		-t $(DOCKER_IMAGE)-alpine:latest \
+		-f Dockerfile.alpine \
+		.
+
+.PHONY: images
+images: image image/alpine
+
+.PHONY: docker/push/latest
+docker/push/version:
+	@docker push $(DOCKER_IMAGE):latest
+	@docker push $(DOCKER_IMAGE)-alpine:latest
+
+.PHONY: docker/push/version
+docker/push/version:
+	@docker push $(DOCKER_IMAGE):$(VERSION)
+	@docker push $(DOCKER_IMAGE)-alpine:$(VERSION)
+
+.PHONY: docker/push
+docker/push: docker/push/version docker/push/latest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_IMAGE=minimsecure/ruby-docker-image
 .PHONY: image
 image:
 	docker build \
-		-t minimsecure/ruby-docker-image:$(VERSION) \
+		-t $(DOCKER_IMAGE):$(VERSION) \
 		-t $(DOCKER_IMAGE):latest \
 		-f Dockerfile \
 		.
@@ -20,15 +20,15 @@ image/alpine:
 .PHONY: images
 images: image image/alpine
 
-.PHONY: docker/push/latest
-docker/push/version:
-	@docker push $(DOCKER_IMAGE):latest
+.PHONY: docker/push/alpine
+docker/push/alpine:
+	@docker push $(DOCKER_IMAGE)-alpine:$(VERSION)
 	@docker push $(DOCKER_IMAGE)-alpine:latest
 
-.PHONY: docker/push/version
-docker/push/version:
+.PHONY: docker/push/image
+docker/push/image:
 	@docker push $(DOCKER_IMAGE):$(VERSION)
-	@docker push $(DOCKER_IMAGE)-alpine:$(VERSION)
+	@docker push $(DOCKER_IMAGE):latest
 
 .PHONY: docker/push
-docker/push: docker/push/version docker/push/latest
+docker/push: docker/push/alpine docker/push/image

--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
 # ruby-docker-image
 This is the Minim base docker image that is bassed off of the base Ruby docker iamge.
 
-# Building
+There are two Dockerfiles, one builds an image based on the `ruby:<version>`
+docker image, the other on the `ruby:<version>-alpine<alpine-version>`.
+
+## Building
 ```
-usage: ./bin/push.sh [IMAGE_TAG]
+# To build the ruby docker image
+$ make image
 
-A tool to build and push this docker container to dockerhub.
-You must be authenticated with docker have have access to the repo.
+# To build the alpine image
+$ make image/alpine
+```
 
-Arguments:
-  [IMAGE_TAG] - The tag name you want the image to have
+Use the `VERSION` environment variable to build a specific tag
+```
+$ VERSION=1.1.1 make image
+$ VERSION=1.1.1 make image/alpine
+```
+
+All builds will tag the version as well as `latest`.
+
+## Pushing Image
+To push the image to docker hub:
+```
+# To push the latest versions
+$ make docker/push/latest
+
+# To push the tagged versions
+$ make docker/push/version
+
+# To push both
+$ make docker/push
 ```


### PR DESCRIPTION
So this adds a `Dockerfile.alpine` and also adds some `Makefile` targets to build various images. I left the script that also builds it, I figure we should also talk about which approach we like better. Personally I like the Makefile targets better because you can chain things together and it's a common place to look for where to do what. We could also just have the `Makefile` targets use the script as well? But in this case, it seems simple enough to just use make.